### PR TITLE
[AEM-4728] Bumping icongs version to latest release 0.13.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "icongs": "git://github.com/natgeo/icongs.git#0.11.1"
+    "icongs": "git://github.com/natgeo/icongs.git#0.13.0"
   },
   "devDependencies": {
     "pygments": "~1.6.0"


### PR DESCRIPTION
https://jira.nationalgeographic.com/browse/AEM-4728

There's a story on the AEM sites to add the "whatsapp" icon to our "Follow Us" component. While looking into the story I found that we're a couple of versions behind on the latest released version of https://github.com/natgeo/icongs/releases

While attempting to update the version required on AEM sites I found that there's also a dependency in Mortar, which made my attempts to update AEM fail in the build process.

This change bumps the version of icongs to the latest release. I'm not clear on procedures needed to fully vet the change. I've done some quick smoke tests of the AEM sites with this updated version of the icon font set which appears to render fine.
