### PR TITLE
[MORTAR-188] Keyboard Navigation for Slider component 

### DIFF
--- a/app/modules/slider/_styles.scss
+++ b/app/modules/slider/_styles.scss
@@ -1,4 +1,6 @@
 .mt_slider-container {
+  z-index: $mt_z-middle;
+    
   img { // this probably needs to go away once the component exists
     height: auto;
     width: 100%;
@@ -15,6 +17,7 @@
   top: 50%;
   transform: translateY(-50%) scale(1.0, 1.0);
   width: $mt-unit * 2.5;
+  z-index: $mt_z-top;
 
   .mt_slider-container--large & {
     height: $mt-unit * 5;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pubsub-js": "^1.5.3",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
-    "react-slick": "^0.12.2"
+    "react-slick": "krlospelaez/react-slick#fix-npm"
   },
   "devDependencies": {
     "babel-core": "^6.8.0",


### PR DESCRIPTION
To test:

- `npm install`
- `gulp serve`
- Go to slider component then click the slider and try to navigate using the keyboard arrows.