### PR TITLE
Remove focus from inactive buttons 

### DIFF
--- a/app/styles/patterns/_partials/buttons-snippets.html
+++ b/app/styles/patterns/_partials/buttons-snippets.html
@@ -4,6 +4,6 @@
 &lt;button class="mt2_btn mt2_btn--naked mt2_fullwidth"&gt; &lt;span&gt; Naked &lt;/span&gt; &lt;/button&gt;
 &lt;button class="mt2_btn mt2_btn--success mt2_fullwidth"&gt;Success&lt;/button&gt;
 &lt;button class="mt2_btn mt2_btn--error mt2_fullwidth"&gt;Error&lt;/button&gt;
-&lt;button class="mt2_btn mt2_btn--default--inactive mt2_fullwidth"&gt;Default Inactive&lt;/button&gt;
-&lt;button class="mt2_btn mt2_btn--secondary--inactive mt2_fullwidth"&gt;Secondary Inactive&lt;/button&gt;
-&lt;button class="mt2_btn mt2_btn--naked mt2_btn--naked--inactive mt2_fullwidth"&gt;Naked Inactive&lt;/button&gt;</code></pre>
+&lt;button class="mt2_btn mt2_btn--default--inactive mt2_fullwidth" disabled&gt;Default Inactive&lt;/button&gt;
+&lt;button class="mt2_btn mt2_btn--secondary--inactive mt2_fullwidth" disabled&gt;Secondary Inactive&lt;/button&gt;
+&lt;button class="mt2_btn mt2_btn--naked mt2_btn--naked--inactive mt2_fullwidth" disabled&gt;Naked Inactive&lt;/button&gt;</code></pre>

--- a/app/styles/patterns/buttons.html
+++ b/app/styles/patterns/buttons.html
@@ -42,13 +42,13 @@
         <button class="mt2_btn mt2_fullwidth mt2_btn--error">Error</button>
       </div>
       <div class="mt2_row-gut-2">
-        <button class="mt2_btn mt2_fullwidth mt2_btn--default--inactive">Default Inactive</button>
+        <button class="mt2_btn mt2_fullwidth mt2_btn--default--inactive" disabled>Default Inactive</button>
       </div>
       <div class="mt2_row-gut-2">
-        <button class="mt2_btn mt2_fullwidth mt2_btn--secondary--inactive">Secondary Inactive</button>
+        <button class="mt2_btn mt2_fullwidth mt2_btn--secondary--inactive" disabled>Secondary Inactive</button>
       </div>
       <div class="mt2_row-gut-2">
-        <button class="mt2_btn mt2_fullwidth mt2_btn--naked mt2_btn--naked--inactive">Naked Inactive</button>
+        <button class="mt2_btn mt2_fullwidth mt2_btn--naked mt2_btn--naked--inactive" disabled>Naked Inactive</button>
       </div>
 
       <!-- Code snippet -->


### PR DESCRIPTION
https://jira.nationalgeographic.com/browse/MORTAR-241

git checkout
gul serve
Focus is removed from inactive buttons so you can no longer tab through. http://localhost:3000/patterns