### PR TITLE
Fix expand button disappearance on small screens

### DIFF
--- a/app/site/_styles/docs.scss
+++ b/app/site/_styles/docs.scss
@@ -443,7 +443,8 @@ code {
   margin: 0;
   padding: 1rem;
 
-  .constrainheight & {
+  .constrainheight &,
+  .constrainheight-mobile & {
     bottom: 0;
     position: absolute;
   }


### PR DESCRIPTION
https://jira.nationalgeographic.com/browse/MORTAR-207

Make sure expand button under code snippets shows up on small screens. *Only* applicable to code snippets with height > 240px
