### PR TITLE
[SYTO-633-imageFix] pass srcset to ImageSlide

### DIFF
--- a/app/modules/photogallery/docs.html
+++ b/app/modules/photogallery/docs.html
@@ -25,7 +25,7 @@
               "caption": "This is Caption One",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -39,7 +39,7 @@
               "caption": "This is Caption Two",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -53,7 +53,7 @@
               "caption": "This is Caption Three",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/300x200.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/300x200.jpg 300w",
                 "http://placehold.it/600x400.jpg 600w",
                 "http://placehold.it/1200x800.jpg 1200w"
@@ -85,7 +85,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption One&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -99,7 +99,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Two&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -113,7 +113,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Three&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/300x200.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/300x200.jpg 300w&#x22;,
             &#x22;http://placehold.it/600x400.jpg 600w&#x22;,
             &#x22;http://placehold.it/1200x800.jpg 1200w&#x22;
@@ -146,7 +146,7 @@
               "caption": "This is Caption One",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -160,7 +160,7 @@
               "caption": "This is Caption Two",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -174,7 +174,7 @@
               "caption": "This is Caption Three",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/300x200.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/300x200.jpg 300w",
                 "http://placehold.it/600x400.jpg 600w",
                 "http://placehold.it/1200x800.jpg 1200w"
@@ -206,7 +206,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption One&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -220,7 +220,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Two&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -234,7 +234,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Three&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/300x200.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/300x200.jpg 300w&#x22;,
             &#x22;http://placehold.it/600x400.jpg 600w&#x22;,
             &#x22;http://placehold.it/1200x800.jpg 1200w&#x22;
@@ -265,7 +265,7 @@
               "caption": "This is Caption One",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -279,7 +279,7 @@
               "caption": "This is Caption Two",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/350x150.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/350x150.jpg 350w",
                 "http://placehold.it/700x300.jpg 700w",
                 "http://placehold.it/1400x600.jpg 1400w"
@@ -293,7 +293,7 @@
               "caption": "This is Caption Three",
               "credit": "Joel Sartore",
               "src": "http://placehold.it/300x200.jpg",
-              "srcSet": [
+              "srcset": [
                 "http://placehold.it/300x200.jpg 300w",
                 "http://placehold.it/600x400.jpg 600w",
                 "http://placehold.it/1200x800.jpg 1200w"
@@ -325,7 +325,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption One&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -339,7 +339,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Two&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/350x150.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/350x150.jpg 350w&#x22;,
             &#x22;http://placehold.it/700x300.jpg 700w&#x22;,
             &#x22;http://placehold.it/1400x600.jpg 1400w&#x22;
@@ -353,7 +353,7 @@
           &#x22;caption&#x22;: &#x22;This is Caption Three&#x22;,
           &#x22;credit&#x22;: &#x22;Joel Sartore&#x22;,
           &#x22;src&#x22;: &#x22;http://placehold.it/300x200.jpg&#x22;,
-          &#x22;srcSet&#x22;: [
+          &#x22;srcset&#x22;: [
             &#x22;http://placehold.it/300x200.jpg 300w&#x22;,
             &#x22;http://placehold.it/600x400.jpg 600w&#x22;,
             &#x22;http://placehold.it/1200x800.jpg 1200w&#x22;

--- a/app/modules/photogallery/scripts/MTPhotoGallery.jsx
+++ b/app/modules/photogallery/scripts/MTPhotoGallery.jsx
@@ -56,7 +56,7 @@ PhotoGallery.propTypes = {
     title: PropTypes.string,
     type: PropTypes.string.isRequired,
     src: PropTypes.string,
-    srcSet: PropTypes.array
+    srcset: PropTypes.array
   })).isRequired,
   title: PropTypes.string
 }

--- a/app/modules/slider/scripts/MTSlider.jsx
+++ b/app/modules/slider/scripts/MTSlider.jsx
@@ -49,7 +49,7 @@ class MTSlider extends Component {
                          letterbox={this.props.letterbox}
                          letterboxBackgroundColor={backgroundColor}
                          src={data.src}
-                         srcset={data.srcSet}/>
+                         srcset={data.srcset}/>
     default:
       return;
     }
@@ -132,7 +132,7 @@ MTSlider.propTypes = {
     title: PropTypes.string,
     type: PropTypes.string.isRequired,
     src: PropTypes.string,
-    srcSet: PropTypes.array
+    srcset: PropTypes.array
   }))
 }
 

--- a/app/modules/slider/scripts/imageSlide.jsx
+++ b/app/modules/slider/scripts/imageSlide.jsx
@@ -12,6 +12,7 @@ class ImageSlide extends Component {
         lazyLoad={true}
         letterbox={this.props.letterbox}
         letterboxBackgroundColor={this.props.letterboxBackgroundColor}
+        src={this.props.src}
         srcset={this.props.srcset}/>
     );
   }
@@ -22,7 +23,8 @@ ImageSlide.propTypes = {
   frameAspectRatio: PropTypes.string,
   letterbox: PropTypes.bool,
   letterboxBackgroundColor: PropTypes.string,
-  src: PropTypes.string
+  src: PropTypes.string,
+  srcset: PropTypes.array
 }
 
 export default ImageSlide;


### PR DESCRIPTION
No ticket associated with this. Refactor to ensure the srcset array is being passed to the ImageSlide for responsive images in the Slider for standalone and in a PhotoGallery.