### PR TITLE
Replace NG missing images URLs for more stable placehold.it URLs.

### DIFF
--- a/app/modules/slider/docs.html
+++ b/app/modules/slider/docs.html
@@ -33,15 +33,15 @@
         "slides": [
           {
             "type": "image",
-            "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96913_photo_vnvd6jocb3hh7gbb4oxwx2ujb5fexm7cgxgwc2j5bhy5ykeydrua_1200x800.jpg"
+            "src": "http://placehold.it/1200x800/000000/ffcc00"
           },
           {
             "type": "image",
-            "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96877_photo_dqpop4tr2wg4gfyyza4uzd44yvfexm7cgxgwc2j5bhy5ykeydrua_1200x800.jpg"
+            "src": "http://placehold.it/1200x800/222141/524261"
           },
           {
             "type": "image",
-            "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96778_photo_dhrcwooticqnnhgtavyhnqd6djfexm7cgxgwc2j5bhy5ykeydrua_1200x800.jpg"
+            "src": "http://placehold.it/1200x800/c86612/fac451"
           }
         ]
       }
@@ -66,15 +66,15 @@
           "slides": [
             {
               "type": "image",
-              "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96913_photo_vnvd6jocb3hh7gbb4oxwx2ujb5fexm7cgxgwc2j5bhy5ykeydrua_850x478.jpg"
+              "src": "http://placehold.it/850x478/000000/ffcc00"
             },
             {
               "type": "image",
-              "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96877_photo_dqpop4tr2wg4gfyyza4uzd44yvfexm7cgxgwc2j5bhy5ykeydrua_850x478.jpg"
+              "src": "http://placehold.it/850x478/222141/524261"
             },
             {
               "type": "image",
-              "src": "http://www.nationalgeographic.com/dc/exposure/homepage/photoconfiguration/image/96778_photo_dhrcwooticqnnhgtavyhnqd6djfexm7cgxgwc2j5bhy5ykeydrua_850x478.jpg"
+              "src": "http://placehold.it/850x478/c86612/fac451"
             }
           ]
         }


### PR DESCRIPTION
Slider examples were using NG images that somehow got missing (removed, moved, whatever).
This PR makes use of placehold.it URLs that are less likely to change and serves the same as purpose is to test slider around.
Te check it:
- See Components section, Slider.
- You should see placeholdit images (colorful squares with size in pixels of the image being fetched).
- Have a beer, you deserve it for sure.