### PR TITLE
[SYTO-759] Create truncate component for playerlist

### DIFF
--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -13,6 +13,7 @@ $mt3_gradient-color: rgba(255, 255, 255, 0);
   .mt3_show-more-link {
     border-bottom: 0;
     color: map-get($mt3_colors, 'neutral--l');
+    cursor: pointer;
     padding-left: 0;
     white-space: nowrap;
 

--- a/app/modules/videoplaylist/scripts/VideoCaption.jsx
+++ b/app/modules/videoplaylist/scripts/VideoCaption.jsx
@@ -1,20 +1,36 @@
 import React, {Component} from 'react';
 import Truncate from 'react-truncate';
 
+const lines = 3;
 /**
  * This component renders the video caption below the video component.
- * TODO: Truncation in the description property
  */
 class VideoCaption extends Component {
 
+  constructor(props) {
+    super(props);
+    this.state= {};
+    this.toggleLines = this.toggleLines.bind(this);
+  }
+
+  toggleLines(evt) {
+    evt.preventDefault();
+    this.setState({readMore: !this.state.readMore});
+  }
+
   render() {
+    const {title, abstract} = this.props;
     return (
       <div>
         <h3 ref="title" className="mt3_h5">
-          <span itemProp='headline' dangerouslySetInnerHTML={{__html: this.props.title}} />
+          <span itemProp='headline' dangerouslySetInnerHTML={{__html: title}} />
         </h3>
-        <div ref="abstract" className="multi-layout-promos__promo-dek">
-          <span itemProp='description' className="mt3_subh4" dangerouslySetInnerHTML={{__html: this.props.abstract}} />
+        <div ref="abstract" className="multi-layout-promos__promo-dek mt3_subh4">
+          <Truncate
+            lines={this.state.readMore ? 0 : lines}
+            ellipsis={<span>... <a onClick={this.toggleLines} className="mt3_show-more-link">Read more</a></span>}>
+            <span itemProp='description' dangerouslySetInnerHTML={{__html: abstract}} />
+          </Truncate>
         </div>
       </div>
     )

--- a/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
+++ b/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
@@ -28,6 +28,12 @@ class VideoPlaylist extends Component {
     this.loadVideo(this.props.dataModel[nextState.currentVideoIndex].directLink, nextState);
   }
 
+  componentDidUpdate() {
+    //This line resolves the problem with the abstract video caption that it need two
+    //clicks to render the proper video's abstract.
+    window.dispatchEvent(new Event('resize'));
+  }
+
   componentDidMount() {
     this.pdkCheck(this.activateEventListeners.bind(this));
   }
@@ -198,10 +204,10 @@ class VideoPlaylist extends Component {
   }
 
   render() {
-    const firstVideo = this.props.dataModel[this.state.currentVideoIndex];
+    const currentVideo = this.props.dataModel[this.state.currentVideoIndex];
     const videoModel = {
       instance: this.playerInstanceName,
-      guid: firstVideo.guid,
+      guid: currentVideo.guid,
       sharing: true,
       overlayPlayButton: true,
       autoPlay: false
@@ -220,7 +226,7 @@ class VideoPlaylist extends Component {
         <div className="mt3_col-12 mt3_col-lg-8 mt3_multi-layout-promos__promo-content">
           <div className="mt3_multi-layout-promos__promo--text__bg"></div>
           <EmbeddedVideo model={videoModel} lazyLoad={true}/>
-          <VideoCaption title={firstVideo.title} abstract={firstVideo.abstract} />
+          <VideoCaption title={currentVideo.title} abstract={currentVideo.abstract} />
         </div>
         <div className="mt3_col-12 mt3_col-lg-4">
           <div ref="thumbnailContainer" className='mt3_video-playlist-container--thumbnails'>


### PR DESCRIPTION
https://jira.natgeo.com/browse/SYTO-759

This PR gives a solution with the truncation of the text below the video component

I reccomend to use charles proxy in order to change this json http://www.nationalgeographic.com/versions/20160804-v1/_jcr_content/content/videoplaylist.promo-all.json and change the abstract property.

#### How to test

1. ``npm i``
2. ``gulp serve``
3. Go to components section
4. Scroll down until videplaylist
5. Check if the caption of the video has truncation when the text is very long.