### PR TITLE
[SYTO-742] Remove Chronicle & Pragmatica

### DIFF
--- a/app/site/_layouts/default.html
+++ b/app/site/_layouts/default.html
@@ -12,7 +12,6 @@
   <link rel="shortcut icon" href="//assets.ngeo.com/favicon/v1/favicon.ico"/>
 
   <link rel="stylesheet" href="{{rootPath}}.{% if title != 'Home' %}.{% endif %}/styles/mortar-default.css">
-  <link rel="stylesheet" href="https://fonts.ngeo.com/hoefler/1-0-1/hco_fonts.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.3.15/slick.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/themes/prism-okaidia.css" />
   <link rel="stylesheet" href="{{rootPath}}.{% if title != 'Home' %}.{% endif %}/styles/docs.css">
@@ -167,15 +166,6 @@
     });
   </script>
 
-  <script>
-  (function(d) {
-    var config = {
-      kitId: 'wdv5zcl',
-      scriptTimeout: 3000
-    },
-    h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='//fonts.ngeo.com/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
-  })(document);
-  </script>
   <script src="{{rootPath}}.{% if title != 'Home' %}.{% endif %}/scripts/main.js"></script>
 </body>
 </html>

--- a/app/styles/themes/default/vars/_typography.scss
+++ b/app/styles/themes/default/vars/_typography.scss
@@ -134,7 +134,7 @@ $mt3_unit-quadruple: $mt3_unit * 4;
 
 
 %mt3_h1 {
-  font-family: Georgia, serif;
+  font-family: 'Chronicle Display 3r', Georgia, serif;
   font-size: $mt3_fs-med-xlrg;
   font-weight: 300;
   letter-spacing: .005em;
@@ -151,7 +151,7 @@ $mt3_unit-quadruple: $mt3_unit * 4;
 }
 
 %mt3_h2 {
-  font-family: Georgia, serif;
+  font-family: 'Chronicle Deck 6r', Georgia, serif;
   font-size: $mt3_fs-xlrg;
   font-weight: 600;
   letter-spacing: .005em;
@@ -168,7 +168,7 @@ $mt3_unit-quadruple: $mt3_unit * 4;
 }
 
 %mt3_h3 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-lrg;
   font-weight: 600;
   letter-spacing: -.01em;
@@ -188,20 +188,20 @@ $mt3_unit-quadruple: $mt3_unit * 4;
 }
 
 %mt3_h5 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-sm;
   font-weight: 600;
 }
 
 %mt3_subh1 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-med;
   font-weight: 300;
   line-height: 1.37;
 }
 
 %mt3_subh2 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-sm;
   font-weight: 300;
   line-height: 1.57;
@@ -209,14 +209,14 @@ $mt3_unit-quadruple: $mt3_unit * 4;
 }
 
 %mt3_subh3 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-xsm;
   font-weight: 300;
   text-transform: uppercase;
 }
 
 %mt3_subh4 {
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
+  font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
   font-size: $mt3_fs-sm;
   font-weight: 300;
   line-height: 1.43;


### PR DESCRIPTION
https://jira.natgeo.com/browse/SYTO-742

Chronicle and Pragmatica are restored to the CSS and removed from HTML as per AC.

Instruction:

- git checkout 
- gulp serve
- Inspect the console to verify the following no longer appear in the head tag:

`<link rel="stylesheet" href="https://fonts.ngeo.com/hoefler/1-0-1/hco_fonts.css">`

- You should no longer see this 
<img width="951" alt="screen shot 2016-09-06 at 3 21 38 pm" src="https://cloud.githubusercontent.com/assets/2752485/18288018/9d3250aa-7447-11e6-98e6-ea71cbe5ce87.png">

