### PR TITLE
Reskin VideoPlaylist Thumbnails Promos Desktop and Mobile

### DIFF
--- a/app/modules/video/scripts/video.jsx
+++ b/app/modules/video/scripts/video.jsx
@@ -61,7 +61,7 @@ class Video extends Component {
 
     if (lazyLoad === true) {
       return (
-        <figure itemType="http://schema.org/VideoObject" className={`mt3_video mt3_videopromo-container mt3_intratio--broadcast mt3_bgcolor--gray5 ${className}` }>
+        <figure itemType="http://schema.org/VideoObject" className={`mt3_video mt3_videopromo-container mt3_intratio--broadcast mt3_bgcolor--black ${className}` }>
           <LazyLoad offsetVertical={200} onContentVisible={this.handleOnLoad.bind(this)}><span>&nbsp;</span></LazyLoad>
           <div className="mt3_video-wrapper" dangerouslySetInnerHTML={{__html: this.videoContainer}}>
           </div>

--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -1,7 +1,3 @@
-//TODO: These are temporary variable with non-existing colors on mortar, when SYTO-781
-//is ready we need to procede to refactor.
-$mt3_gray-40: #999;
-
 .mt3_video-playlist {
 
   &__flex {
@@ -64,7 +60,6 @@ $mt3_gray-40: #999;
     padding: 40px 80px 0 60px;
 
     &__description {
-      color: $mt3_gray-40;
       font-family: $mt3_georgia-stack;
       font-size: 15px;
       font-weight: normal;
@@ -137,14 +132,14 @@ $mt3_gray-40: #999;
     }
 
     @include respond-to(m) {
-      background-color: map-get($mt3_colors, 'gray80');
+      background-color: $mt3_color-black;
       margin-left: 0;
       order: 1;
       padding: 15px 70px 40px;
     }
 
     @include respond-to(s) {
-      background-color: map-get($mt3_colors, 'gray80');
+      background-color: $mt3_color-black;
       margin-left: 0;
       order: 1;
       padding: 15px 30px 40px;
@@ -260,7 +255,7 @@ $mt3_gray-40: #999;
 
     .modules-images {
       &:before {
-        background-color: map-get($mt3_colors, 'primary');
+        background-color: $mt3_color-primary;
       }
     }
 

--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -1,4 +1,4 @@
-$mt3_playlist-desktop-height: 470px;
+$mt3_playlist-desktop-height: 780px;
 $mt3_gradient-color: rgba(255, 255, 255, 0);
 
 //TODO: These are temporary variable with non-existing colors on mortar, when SYTO-781
@@ -130,7 +130,7 @@ $mt3_gray-40: #999;
         display: none;
       }
 
-      border-left: 1px solid map-get($mt3_colors, 'gray50');
+      border-left: 1px solid map-get($mt3_colors, 'neutral');
       padding-bottom: 40px;
     }
 
@@ -140,14 +140,14 @@ $mt3_gray-40: #999;
     }
 
     @include respond-to(m) {
-      background-color: map-get($mt3_colors, 'gray80');
+      background-color: map-get($mt3_colors, 'neutral--xxd');
       margin-left: 0;
       order: 1;
       padding: 15px 70px 40px;
     }
 
     @include respond-to(s) {
-      background-color: map-get($mt3_colors, 'gray80');
+      background-color: map-get($mt3_colors, 'neutral--xxd');
       margin-left: 0;
       order: 1;
       padding: 15px 30px 40px;
@@ -176,7 +176,7 @@ $mt3_gray-40: #999;
 
     @media #{$mt3_mq-lg} {
       &::after {
-        background: linear-gradient(to bottom, $mt3_gradient-color 0%, map-get($mt3_colors, 'white') 100%);
+        background: linear-gradient(to bottom, $mt3_gradient-color 0%, map-get($mt3_colors, 'neutral--xxxl') 100%);
         bottom: 0;
         content: ' ';
         height: 70px;
@@ -202,8 +202,8 @@ $mt3_gray-40: #999;
   }
 
   &-container--thumbnail {
-    border-bottom: 1px solid map-get($mt3_colors, 'gray10');
-    color: map-get($mt3_colors, 'gray80');
+    border-bottom: 1px solid map-get($mt3_colors, 'neutral--xl');
+    color: map-get($mt3_colors, 'neutral--xd');
     cursor: pointer;
     font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
     font-size: 14px;
@@ -263,6 +263,6 @@ $mt3_gray-40: #999;
   }
 
   &-container--active-thumbnail {
-    background-color: map-get($mt3_colors, 'gray5');
+    background-color: map-get($mt3_colors, 'neutral--xxl');
   }
 }

--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -127,7 +127,7 @@ $mt3_gray-40: #999;
         display: none;
       }
 
-      border-left: 1px solid map-get($mt3_colors, 'neutral');
+      border-left: 1px solid map-get($mt3_colors, 'gray50');
       padding-bottom: 40px;
     }
 
@@ -137,14 +137,14 @@ $mt3_gray-40: #999;
     }
 
     @include respond-to(m) {
-      background-color: map-get($mt3_colors, 'neutral--xxd');
+      background-color: map-get($mt3_colors, 'gray80');
       margin-left: 0;
       order: 1;
       padding: 15px 70px 40px;
     }
 
     @include respond-to(s) {
-      background-color: map-get($mt3_colors, 'neutral--xxd');
+      background-color: map-get($mt3_colors, 'gray80');
       margin-left: 0;
       order: 1;
       padding: 15px 30px 40px;

--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -172,7 +172,7 @@ $mt3_gray-40: #999;
 
     // Tablet
     @include respond-to(m) {
-      padding: 0 70px 60px;
+      padding: 0 70px 30px;
     }
 
     @include respond-to(xl) {
@@ -227,12 +227,6 @@ $mt3_gray-40: #999;
       }
     }
 
-    @include respond-to(s) {
-      .modules-images {
-        max-height: 190px;
-      }
-    }
-
     @include respond-to(m) {
       width: 50%;
       display: inline-block;
@@ -254,6 +248,7 @@ $mt3_gray-40: #999;
           left: 15px;
         }
       }
+
     }
 
   }

--- a/app/modules/videoplaylist/_styles.scss
+++ b/app/modules/videoplaylist/_styles.scss
@@ -1,6 +1,3 @@
-$mt3_playlist-desktop-height: 780px;
-$mt3_gradient-color: rgba(255, 255, 255, 0);
-
 //TODO: These are temporary variable with non-existing colors on mortar, when SYTO-781
 //is ready we need to procede to refactor.
 $mt3_gray-40: #999;
@@ -162,107 +159,130 @@ $mt3_gray-40: #999;
   }
 
   &-container--thumbnails {
-    @media #{$mt3_mq-lg} {
-      margin-left: 40px;
-      max-height: $mt3_playlist-desktop-height;
-      width: 92%;
-    }
+    background-color: $mt3_color-black;
     overflow: hidden;
     position: relative;
     transition-duration: 1s;
     transition-property: max-height;
     transition-timing-function: ease-in-out;
 
-
-    @media #{$mt3_mq-lg} {
-      &::after {
-        background: linear-gradient(to bottom, $mt3_gradient-color 0%, map-get($mt3_colors, 'neutral--xxxl') 100%);
-        bottom: 0;
-        content: ' ';
-        height: 70px;
-        left: 0;
-        opacity: 1;
-        pointer-events: none;
-        position: absolute;
-        transition-duration: .5s;
-        transition-property: opacity;
-        transition-timing-function: ease-in-out;
-        width: 100%;
-        z-index: 20;
-      }
+    @include respond-to(s) {
+      padding: 0 30px 30px;
     }
 
-    &__scroll {
-      @media #{$mt3_mq-lg} {
-        max-height: $mt3_playlist-desktop-height;
-        overflow-y: scroll;
-        padding-bottom: 35px;
-      }
+    // Tablet
+    @include respond-to(m) {
+      padding: 0 70px 60px;
+    }
+
+    @include respond-to(xl) {
+      padding-right: 70px;
     }
   }
 
   &-container--thumbnail {
-    border-bottom: 1px solid map-get($mt3_colors, 'neutral--xl');
-    color: map-get($mt3_colors, 'neutral--xd');
-    cursor: pointer;
-    font-family: 'Pragmatica-web', 'Helvetica Neue', Helvetica, Arial, 'Nimbus Sans L', sans-serif;
-    font-size: 14px;
-    font-weight: bold;
-    line-height: 22px;
-    padding: 16px;
+    overflow: hidden;
+    position: relative;
 
-    a {
-      @extend %mt3_textlink;
-      align-items: center;
+    // container text over the image.
+    .thumbnail-overlay {
+      bottom: 0;
+      color: $mt3_color-white;
       display: flex;
+      flex-direction: column;
+      font-family: $mt3_haas-stack;
+      font-size: 18px;
+      font-weight: 600;
+      justify-content: center;
+      left: 0px;
+      letter-spacing: 0.05em;
+      line-height: 1.43;
+      padding: 0 30px;
+      position: absolute;
+      right: 0;
+      text-decoration: none;
+      top: 0;
+      z-index: $mt3_z-middle + 1;
 
       &:hover,
       &:focus,
       &:active {
-        color: inherit;
-      }
-
-      &.mt3_none {
-        border-bottom: 0;
+        outline: 0;
       }
     }
 
-    &:last-of-type {
-      border-bottom: 0;
-    }
-
-    figure {
-      margin: 0 16px;
-      min-width: 120px;
-      position: relative;
-      width: 120px;
-
-      &:not(.embedded-video)::before {
-        background-image: $mt3_video-promo-play-button;
-        background-repeat: no-repeat;
-        background-size: 100%;
+    .modules-images {
+      &:before {
+        background-color: black;
         content: '';
-        display: block;
-        height: 45px;
-        left: 50%;
+        height: 100%;
         position: absolute;
-        text-align: center;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        width: 45px;
-        z-index: 10;
+        width: 100%;
+        z-index: $mt3_z-middle + 1;
+      }
+
+      img {
+        opacity: .4;
+        z-index: $mt3_z-middle + 1;
       }
     }
-  }
 
-  & .mt3_hide-play {
-
-    figure:not(.embedded-video)::before {
-      display: none;
+    @include respond-to(s) {
+      .modules-images {
+        max-height: 190px;
+      }
     }
+
+    @include respond-to(m) {
+      width: 50%;
+      display: inline-block;
+      margin-bottom: 30px;
+
+      // left column
+      &:nth-child(odd) {
+        padding-right: 15px;
+
+        .thumbnail-overlay {
+          right: 15px;
+        }
+      }
+      // right column
+      &:nth-child(even) {
+        padding-left: 15px;
+
+        .thumbnail-overlay {
+          left: 15px;
+        }
+      }
+    }
+
   }
 
   &-container--active-thumbnail {
-    background-color: map-get($mt3_colors, 'neutral--xxl');
+    .thumbnail-overlay {
+      color: $mt3_color-black;
+    }
+
+    .modules-images {
+      &:before {
+        background-color: map-get($mt3_colors, 'primary');
+      }
+    }
+
+    @media #{$mt3_mq-md} {
+      &:after {
+        content: "";
+        display: block;
+        height: 0px;
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0px;
+        z-index: $mt3_z-middle + 1;
+        border-bottom: 15px solid transparent;
+        border-left: 15px solid $mt3_color-black;
+        border-top: 15px solid transparent;
+      }
+    }
   }
 }

--- a/app/modules/videoplaylist/scripts/VideoCaption.jsx
+++ b/app/modules/videoplaylist/scripts/VideoCaption.jsx
@@ -31,7 +31,7 @@ class VideoCaption extends Component {
 
   truncateAbstract() {
     $(this.refs.abstract).css({height: '6em'}).dotdotdot({
-      after: $('<a class="mt3_show-more-link mt3_color--black" href="#">Read More</a>'),
+      after: $('<a class="mt3_show-more-link mt3_color--white" href="#">Read More</a>'),
       callback: (isTruncated, original) => {
         const $abstractEl = $(this.refs.abstract);
         if (!isTruncated) {
@@ -50,13 +50,13 @@ class VideoCaption extends Component {
   render() {
     const {title, abstract} = this.props;
     return (
-      <div className="mt3_video-playlist--current-information mt3_bgcolor--gray66">
-        <h3 ref="title" className="mt3_video-playlist--current-information__title mt3_color--black">
+      <div className="mt3_video-playlist--current-information mt3_bgcolor--gray80">
+        <h3 ref="title" className="mt3_video-playlist--current-information__title mt3_color--white">
           <span itemProp='headline' dangerouslySetInnerHTML={{__html: title}} />
         </h3>
 
         <figcaption className="mt3_caption-container--indent mt3_caption-container--indent--gray">
-          <div ref="abstract"  className="mt3_caption-body mt3_video-playlist--current-information__description">
+          <div ref="abstract"  className="mt3_caption-body mt3_video-playlist--current-information__description mt3_color--gray40">
             <span itemProp='description' dangerouslySetInnerHTML={{__html: abstract}} />
           </div>
         </figcaption>

--- a/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
+++ b/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
@@ -216,11 +216,11 @@ class VideoPlaylist extends Component {
       return <VideoThumbnail key={index} wrapperClass={thumbClass} item={item} onClick={this.handleClick.bind(this, index)}/>
     });
     return(
-      <div ref="mainVideoContainer" className="mt3_col-12 mt3_col-lg-12 mt3_bgcolor--gray80">
+      <div ref="mainVideoContainer" className="mt3_col-12 mt3_col-lg-12 mt3_bgcolor--black">
         <div className="mt3_col-12 mt3_col-md-9 mt3_video-playlist__flex">
           <div className="mt3_video-playlist__main-head">
             <div className="mt3_video-playlist--heading mt3_video-playlist--heading--border">
-              <div className="mt3_video-playlist--heading__title mt3_color--black">{this.props.header}</div>
+              <div className="mt3_video-playlist--heading__title mt3_color--white">{this.props.header}</div>
             </div>
           </div>
           <VideoCaption

--- a/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
+++ b/app/modules/videoplaylist/scripts/VideoPlaylist.jsx
@@ -217,7 +217,7 @@ class VideoPlaylist extends Component {
     });
     return(
       <div ref="mainVideoContainer" className="mt3_col-12 mt3_col-lg-12 mt3_bgcolor--gray80">
-        <div className="mt3_col-12 mt3_col-lg-8 mt3_video-playlist__flex">
+        <div className="mt3_col-12 mt3_col-md-9 mt3_video-playlist__flex">
           <div className="mt3_video-playlist__main-head">
             <div className="mt3_video-playlist--heading mt3_video-playlist--heading--border">
               <div className="mt3_video-playlist--heading__title mt3_color--black">{this.props.header}</div>
@@ -231,7 +231,7 @@ class VideoPlaylist extends Component {
           />
           <EmbeddedVideo model={videoModel} lazyLoad={true}/>
         </div>
-        <div className="mt3_col-12 mt3_col-lg-4">
+        <div className="mt3_col-12 mt3_col-md-3">
           <div ref="thumbnailContainer" className='mt3_video-playlist-container--thumbnails'>
             <div className="mt3_video-playlist-container--thumbnails__scroll">
               {thumbnails}

--- a/app/modules/videoplaylist/scripts/VideoThumbnail.jsx
+++ b/app/modules/videoplaylist/scripts/VideoThumbnail.jsx
@@ -11,6 +11,7 @@ class VideoThumbnail extends Component {
 
   render() {
     const imageModel = {
+      placeholderBackgroundColor: '#000000',
       src: this.props.item.thumbnail,
       isVideo: true,
       lazyLoad: true,
@@ -21,7 +22,7 @@ class VideoThumbnail extends Component {
       <div className={this.props.wrapperClass}>
         <Image {...imageModel} />
         <a href={this.props.item.path} className="thumbnail-overlay mt3_none" title={this.props.item.title} data-guid={this.props.item.guid} onClick={this.onClick.bind(this)}>
-          <Truncate lines={3} ellipsis={(<span>...</span>)}>
+          <Truncate lines={2} ellipsis={(<span>...</span>)}>
             <div ref="videoTitle"  dangerouslySetInnerHTML={{__html: this.props.item.title}} />
           </Truncate>
         </a>

--- a/app/modules/videoplaylist/scripts/VideoThumbnail.jsx
+++ b/app/modules/videoplaylist/scripts/VideoThumbnail.jsx
@@ -19,8 +19,8 @@ class VideoThumbnail extends Component {
 
     return (
       <div className={this.props.wrapperClass}>
-        <a href={this.props.item.path} className="mt3_none" title={this.props.item.title} data-guid={this.props.item.guid} onClick={this.onClick.bind(this)}>
-          <Image {...imageModel} />
+        <Image {...imageModel} />
+        <a href={this.props.item.path} className="thumbnail-overlay mt3_none" title={this.props.item.title} data-guid={this.props.item.guid} onClick={this.onClick.bind(this)}>
           <Truncate lines={3} ellipsis={(<span>...</span>)}>
             <div ref="videoTitle"  dangerouslySetInnerHTML={{__html: this.props.item.title}} />
           </Truncate>

--- a/app/styles/themes/default/vars/_mqs.scss
+++ b/app/styles/themes/default/vars/_mqs.scss
@@ -1,6 +1,10 @@
-$mt3_mq-sm: 'screen and (min-width: 30em)';
-$mt3_mq-md: 'screen and (min-width: 50em)';
-$mt3_mq-lg: 'screen and (min-width: 70em)';
+$screen-s: 30em;
+$screen-m: 50em;
+$screen-l: 70em;
+
+$mt3_mq-sm: 'screen and (min-width: #{$screen-s})';
+$mt3_mq-md: 'screen and (min-width: #{$screen-m})';
+$mt3_mq-lg: 'screen and (min-width: #{$screen-l})';
 
 // Example Use
 // ===========
@@ -20,30 +24,26 @@ $mt3_layout-bps: (
   lg: $mt3_mq-lg
 );
 
-$screen-s: 768px;
-$screen-m: 1024px;
-$screen-l: 1280px;
-
 // This function check if the screen responds to the proper size
 // @param $breakpoint this parameter accept s, m, l, xl values.
 @mixin respond-to($breakpoint) {
 
   @if $breakpoint == s {
-    @media (max-width: #{$screen-s - 1}) {
+    @media (max-width: #{$screen-s - 0.01}) {
       @content;
     }
   }
 
   @else if $breakpoint == m {
     // respond to medium and small
-    @media (min-width: #{$screen-s}) and (max-width: #{$screen-m - 1}) {
+    @media (min-width: #{$screen-s}) and (max-width: #{$screen-m - 0.01}) {
       @content;
     }
   }
 
   @else if $breakpoint == l {
     // respond to medium and bigweb
-    @media (min-width: #{$screen-m}) and (max-width: #{$screen-l - 1}) {
+    @media (min-width: #{$screen-m}) and (max-width: #{$screen-l - 0.01}) {
       @content;
     }
   }


### PR DESCRIPTION
This PR intends to apply miumum css changes in order to reskin thumbnail list for large and desktop breakpoints.

- git checkjout feature/SYTO-797
- gulp serve

Small Desk:
![image](https://cloud.githubusercontent.com/assets/5148689/18369316/63830cae-75fb-11e6-939f-af0997a70fb1.png)

Large Desk:
![image](https://cloud.githubusercontent.com/assets/5148689/18369387/cf158276-75fb-11e6-801f-60d7a403f4f6.png)
