### PR TITLE
[SYTO-822] Fixes typo in link to configurator

### DIFF
--- a/app/contentPackages/contentpackage/docs.html
+++ b/app/contentPackages/contentpackage/docs.html
@@ -5,7 +5,7 @@
         The content package component as currently data modeled is meant to create the "Most Read" and "The Latest" components that will be featured on the Homepage. Currently, only "The Latest" component with mininmal styling is accounted for. "Most Read" and styling will be handled in future stories.
       </p>
       <p class="mt3_subh4">
-        To experiment with different configuration options, visit the <a href="contentpackage/index.html" class="mt3_h5 mt3_textlink">Content Package Configurator</a>.
+        To experiment with different configuration options, visit the <a href="contentPackage/index.html" class="mt3_h5 mt3_textlink">Content Package Configurator</a>.
       </p>
   </div>
 


### PR DESCRIPTION
To test:

- Pull SYTO-822-2
- Run gulp serve
- Head over to http://localhost:3000/contentPackages/
- Confirm Configurator link takes you to http://localhost:3000/contentPackages/contentPackage/index.html