### PR TITLE
[AEM-5957] Fix a few odds and ends related to using m3 components in AEM

### DIFF
--- a/app/scripts/util/PortalComponentMixin.jsx
+++ b/app/scripts/util/PortalComponentMixin.jsx
@@ -29,6 +29,7 @@ var PortalComponentMixin = {
 			this._target = document.createElement('div');
 			document.body.appendChild(this._target);
 		}
+		
 		this._renderLayer();
 	},
 	_renderLayer: function() {
@@ -39,8 +40,8 @@ var PortalComponentMixin = {
 		React.unmountComponentAtNode(this._target);
 	},
 	render: function() {
-		if (!this.props.targetDivId && !this.props.targetDiv && !this.props.targetElementQuery) {
-			return this.renderLayer();
+		if (this.props.targetDivId || this.props.targetDiv || this.props.targetElementQuery) {
+			return null;
 		} else {
 			return <span className="portalComponentFailure"/>;
 		}

--- a/app/scripts/util/PortalWrapper.jsx
+++ b/app/scripts/util/PortalWrapper.jsx
@@ -14,7 +14,7 @@ var PortalWrapper = React.createClass({
 
     renderLayer() {
         return (
-          <div className="portar-wrapper">
+          <div className="portal-wrapper mt3_row">
             {this.props.children}
           </div>
         );

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -16,4 +16,8 @@ gulp.task('copy', function() {
   // contentPackages
   gulp.src(paths.modulesContentPackageSrc)
     .pipe(gulp.dest(paths.modulesContentPackageDest));
+
+  // util scripts
+  gulp.src(paths.utilScriptsSrc)
+    .pipe(gulp.dest(paths.utilScriptsDest));
 });

--- a/gulp/tasks/paths.js
+++ b/gulp/tasks/paths.js
@@ -22,5 +22,8 @@ module.exports = {
     pestleDest: 'packages/pestle',
 
     modulesContentPackageSrc: './app/contentPackages/**/*.{js,jsx,scss,css}',
-    modulesContentPackageDest: 'lib/contentPackages/'
+    modulesContentPackageDest: 'lib/contentPackages/',
+
+    utilScriptsSrc: './app/scripts/util/**/*.{js,jsx}',
+    utilScriptsDest: 'lib/scripts/util/'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@natgeo/mortar_v3",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "a living styleguide for National Geographic Partners",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jquery": "2.x",
     "react": "^0.14.8 || ^15.1.0",
     "react-dom": "^0.14.8 || ^15.1.0",
+    "react-element-query": "^2.0.2",
     "velocity-animate": "1.x"
   },
   "devDependencies": {
@@ -97,7 +98,6 @@
     "react": "^0.14.8",
     "react-addons-test-utils": "^0.14.8",
     "react-dom": "^0.14.8",
-    "react-element-query": "^2.0.2",
     "react-slick": "krlospelaez/react-slick#fix-npm",
     "require-dir": "^0.3.0",
     "scrollmagic": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "picturefill": "3.x",
     "react": "^0.14.8",
     "react-deep-force-update": "^2.0.1",
-    "react-dom": "^0.14.8",
+    "react-dom": "^0.14.8",    
+    "react-element-query": "^2.0.2",
     "react-lazy-load": "3.x",
     "react-pure-render": "1.x",
     "react-slick": "krlospelaez/react-slick#fix-npm",
@@ -42,7 +43,6 @@
     "jquery": "2.x",
     "react": "^0.14.8 || ^15.1.0",
     "react-dom": "^0.14.8 || ^15.1.0",
-    "react-element-query": "^2.0.2",
     "velocity-animate": "1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
in the work for https://jira.natgeo.com/browse/AEM-5957, we identified a couple small changes needed in Mortar - 

1. react-element-query is only a devDependency - it should be a peerDependency
2. the contents of the app/scripts/util file should be available in /lib
3. small tweaks to the Portal components
