### PR TITLE
[SYTO-867] Change default placeholder color

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "src"
   ],
   "dependencies": {
-    "@natgeo/modules-images": "^1.0.2",
+    "@natgeo/modules-images": "^2.0.0",
     "@natgeo/modules-video": "1.2.5",
     "@natgeo/mortar-pestle": "2.x",
     "gsap": "^1.19.0",

--- a/src/modules/video/_styles.scss
+++ b/src/modules/video/_styles.scss
@@ -3,6 +3,7 @@
     height: 100%;
     position: relative;
     width: 100%;
+    z-index: 2;
 
     video,
     iframe {
@@ -15,5 +16,17 @@
     position: absolute;
     top: 0;
     width: 100%;
+    background-color: $mt3_default-modules-images-background;
+    &:after {
+      border: 6px solid $mt3_default-modules-images-box-logo;
+      box-sizing: border-box;
+      content: " ";
+      height: 58px;
+      left: 50%;
+      margin: -29px 0 0 -20px;
+      position: absolute;
+      top: 50%;
+      width: 40px;
+    }
   }
 }

--- a/src/styles/themes/default/vars/_colors.scss
+++ b/src/styles/themes/default/vars/_colors.scss
@@ -4,6 +4,10 @@ $mt3_color-danger: #FC4349;
 $mt3_color-sponsor: #7694CB;
 $mt3_color-gray-50: #808080;
 
+//some vars to match placeholder colors against the defaults in modules-images
+$mt3_default-modules-images-background: rgba(179,179,179,0.4);
+$mt3_default-modules-images-box-logo: #FFCC00;
+
 $mt3_colors: (
   primary: $mt3_color-primary,
   affirmation: $mt3_color-affirmation,


### PR DESCRIPTION
https://jira.natgeo.com/browse/SYTO-867

This work pulls in the most recent update to modules-images: https://github.com/natgeo/modules-images, which has a new default placeholder color for images.

In addition, a placeholder was added to the video player that matches the new defaults in modules-images, per the ticket.

To test:
- npm i
- build
- confirm new placeholder color appears for images and video where appropriate