### PR TITLE
[bug/SYTO-1119] - Video playlist sometimes does not change videos.

### DIFF
--- a/src/modules/video/video.js
+++ b/src/modules/video/video.js
@@ -44,9 +44,13 @@ class Video extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.willUnmount = true;
+  }
+
   handleOnLoad() {
     // if we are not using editmode
-    if (this.props.isEditMode !== true) {
+    if ((this.props.isEditMode !== true) && (!this.willUnmount)) {
       this.createPlayer();
     }
   }

--- a/src/modules/video/video.js
+++ b/src/modules/video/video.js
@@ -12,6 +12,7 @@ class Video extends Component {
 
   constructor(props) {
     super(props);
+    this.handleOnLoad = this.handleOnLoad.bind(this);
     this.videoContainer = `<div id="${props.model.instance}" class="mt3_video-player" data-guid="${props.model.guid}"></div>`;
   }
 
@@ -68,24 +69,21 @@ class Video extends Component {
       }
     } = this.props;
 
-    if (lazyLoad === true) {
-      return (
-        <figure itemType="http://schema.org/VideoObject" className={`mt3_video mt3_videopromo-container mt3_bgcolor--black ${className}` }>
-          <div className="mt3_video-wrapper" dangerouslySetInnerHTML={{__html: this.videoContainer}}>
-          </div>
-          <LazyLoad offsetVertical={200} onContentVisible={this.handleOnLoad.bind(this)}>
-            <span />
+    return (
+      <figure itemType="http://schema.org/VideoObject" className={`mt3_video mt3_videopromo-container mt3_bgcolor--black ${className}` }>
+        <div className="mt3_video-wrapper" dangerouslySetInnerHTML={{__html: this.videoContainer}}>
+        </div>
+        { lazyLoad &&
+          /** Don't use LazyLoad's onContentVisible callback.
+           * Lazyload triggers twice the callback if the element
+           * was on the viewport at first mount.
+           **/
+          <LazyLoad offsetVertical={200}>
+            <span ref={() => { this.handleOnLoad() }}/>
           </LazyLoad>
-        </figure>
-      );
-    } else {
-      return (
-        <figure itemType="http://schema.org/VideoObject" className={`mt3_video mt3_videopromo-container mt3_bgcolor--gray5 ${className}` }>
-          <div className="mt3_video-wrapper" dangerouslySetInnerHTML={{__html: this.videoContainer}}>
-          </div>
-        </figure>
-      );
-    }
+        }
+      </figure>
+    );
   }
 }
 


### PR DESCRIPTION
This PR intends to fix mortar videoplaylist when using latest modules-video (1.3.2).
You can test this only using the latest version modules video: blocker SYTO-1113
- git checkout bug/SYTO-1119
- gulp serve
- navigate to localhost:3000/components/
- scroll down to the videoplaylist, standing at there refresh the page.
- ensure the browser loads the page from that standing point and click on the videoplaylist items
- expected: the video should load.
---

JIRA: https://jira.natgeo.com/browse/SYTO-1119
