### PR TITLE
[AEM-6652] 4-Up margin in first 2 promos prevents even rails when scrolling

### DIFF
--- a/src/contentPackages/contentpackage/components/FourUp.js
+++ b/src/contentPackages/contentpackage/components/FourUp.js
@@ -108,7 +108,8 @@ class FourUpComponent extends Component {
     ];
 
     // This sets the markup for the last two components when the parent component's width is >= 440
-    const tabDeskBottomRow = (
+    // Only create this row if cards are present to account for bottom alignment with left rail
+    const tabDeskBottomRow = this.storyCards[2] ? (
       <div className="mt3_row mt3_fourup-row">
         <div className="mt3_col-6 mt3_fourup-col--extrasmall">
           {this.storyCards[2]}
@@ -116,7 +117,7 @@ class FourUpComponent extends Component {
         <div className="mt3_col-6 mt3_fourup-col--extrasmall">
           {this.storyCards[3]}
         </div>
-      </div>);
+      </div>) : null;
 
     const bottomRow = (this.state.contentWidth < 440) ? mobileBottomRows : tabDeskBottomRow;
 


### PR DESCRIPTION
https://jira.natgeo.com/browse/AEM-6652

This may be tested in Mortar by deleting all cards except the first two, and in AEM (after copying /lib) any page that has a Content Package present such as http://aem.localhost.nationalgeographic.com:4502/content/ngdotcom/en_US/versions/v1.html,
which I believe should be present if the Homepage content package was installed previously.
