### PR TITLE
Quick fix for test.

### DIFF
--- a/src/modules/videoplaylist/VideoCaption.js
+++ b/src/modules/videoplaylist/VideoCaption.js
@@ -42,27 +42,34 @@ class VideoCaption extends Component {
   }
 
   onAnimationEnd(event) {
-    if(event.propertyName === 'height') {
+    if (event.propertyName === 'height') {
       this.props.onAnimationEnd();
     }
   }
 
   truncateAbstract() {
-    $(this.refs.abstract).css({height: '6em'}).dotdotdot({
-      after: $('<a class="mt3_show-more-link mt3_color--white" href="#">Read More</a>'),
-      callback: (isTruncated, original) => {
-        const $abstractEl = $(this.refs.abstract);
-        if (!isTruncated) {
-          $abstractEl.css({height: 'auto'});
-        }
-        $('.mt3_show-more-link').on('click', (event) => {
-          event.preventDefault();
-          $abstractEl
-            .trigger('destroy')
-            .css({ height: 'auto' });
+    let abstractElem = $(this.refs.abstract);
+    if (abstractElem) {
+      abstractElem
+        .css({height: '6em'})
+        .dotdotdot({
+          after: $('<a class="mt3_show-more-link mt3_color--white" href="#">Read More</a>'),
+          callback: (isTruncated, original) => {
+            const $abstractEl = $(this.refs.abstract);
+
+            if (!isTruncated) {
+              $abstractEl.css({height: 'auto'});
+            }
+
+            $('.mt3_show-more-link').on('click', (event) => {
+              event.preventDefault();
+              $abstractEl
+                .trigger('destroy')
+                .css({ height: 'auto' });
+            });
+          }
         });
-      }
-    });
+    }
   }
 
   refreshParentHeight(el) {


### PR DESCRIPTION
Apparently there're a couple of errors being spitted from enzyme's `shallow` when tests finish.
This time bamboo's log says that:
```
>> http://bamboo.int.ngeo.com/download/MPPRJ-MN-MORT2UNT/build_logs/MPPRJ-MN-MORT2UNT-118.log

build	05-Dec-2016 17:54:52	PhantomJS 2.1.1 (Linux 0.0.0) ERROR
build	05-Dec-2016 17:54:52	  TypeError: undefined is not a function (evaluating '(0,_jquery2.default)(this.refs.abstract).css({height:'6em'}).dotdotdot')
build	05-Dec-2016 17:54:52	  at /tmp/b417f9448444231805651e2aa920f23b.browserify:96727 <- src/modules/videoplaylist/VideoCaption.js:9:0
```

so, now it checks for existence of element before calling `.css()`. Further cleanup and fixing is coming in future PR.
Thanks.